### PR TITLE
Support student groups

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -269,6 +269,7 @@ var CourseQueue = React.createClass({
             segmentClass={segmentClass}
             requests={this.state.requests}
             currentUserId={this.props.currentUserId}
+            currentGroupId={this.props.groupMode ? this.props.courseGroupId : null}
             resolve={this.props.instructor ? this.handler.resolveRequest.bind(this.handler) : null}
             bump={this.props.instructor ? this.handler.bump.bind(this.handler) : null}
           />

--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -151,9 +151,26 @@ var CourseQueue = React.createClass({
     });
   },
   getMyFirstRequest: function () {
-    var index = this.state.requests.map(function (elt) {
-      return elt.requester_id;
-    }).indexOf(this.props.currentUserId);
+    var index = -1;
+    if (this.props.groupMode) {
+      index = this.state.requests.map(function (elt) {
+        if (elt.course_group_id !== null) {
+          return elt.course_group_id;
+        } else {
+          // don't count queue items without a group id
+          return -1;
+        }
+      }).indexOf(this.props.courseGroupId);
+    }
+
+    if (index < 0) {
+      // look for requests by our user if we didn't find one by the same group
+      // or are not in group mode. the reason being if for some reason the group
+      // id changes, we don't want the request to just get stranded.
+      index = this.state.requests.map(function (elt) {
+        return elt.requester_id;
+      }).indexOf(this.props.currentUserId);
+    }
 
     if (index >= 0) {
       return {
@@ -207,6 +224,7 @@ var CourseQueue = React.createClass({
           updateRequest={this.handler.updateRequest.bind(this.handler)}
           myRequest={this.getMyFirstRequest()}
           queueClosed={this.state.instructors.length <= 0}
+          groupMode={this.props.groupMode}
         />
       );
     }

--- a/app/assets/javascripts/components/request.js.jsx
+++ b/app/assets/javascripts/components/request.js.jsx
@@ -35,7 +35,9 @@ var Request = React.createClass({
     }
 
     var active = "";
-    if (this.props.request.requester.id === this.props.currentUserId) {
+    var isUserRequester  = this.props.request.requester.id === this.props.currentUserId;
+    var isGroupRequester = this.props.request.course_group_id === this.props.currentGroupId;
+    if (isUserRequester || (this.props.currentGroupId && isGroupRequester)) {
       active = 'active ';
     }
 

--- a/app/assets/javascripts/components/request_box.js.jsx
+++ b/app/assets/javascripts/components/request_box.js.jsx
@@ -9,6 +9,7 @@ var RequestBox = React.createClass({
         <RequestList
           requests={this.props.requests}
           currentUserId={this.props.currentUserId}
+          currentGroupId={this.props.currentGroupId}
           resolve={this.props.resolve}
           bump={this.props.bump} />
       </div>

--- a/app/assets/javascripts/components/request_list.js.jsx
+++ b/app/assets/javascripts/components/request_list.js.jsx
@@ -6,6 +6,7 @@ var RequestList = React.createClass({
           key={request.id}
           request={request}
           currentUserId={this.props.currentUserId}
+          currentGroupId={this.props.currentGroupId}
           resolve={this.props.resolve}
           bump={this.props.bump}
         />

--- a/app/assets/javascripts/components/student_panel.js.jsx
+++ b/app/assets/javascripts/components/student_panel.js.jsx
@@ -81,9 +81,18 @@ var StudentPanel = React.createClass({
       || (!this.state.editMode
         && this.state.myRequest.hasOwnProperty('created_at'));
 
+    if (this.props.groupMode) {
+      var groupModeLabel = (
+          <div className="ui tiny teal label">Group Mode</div>
+      );
+    }
+
     return (
       <div className={this.props.segmentClass}>
-        <h4 className="ui header">Request Help</h4>
+        <h4 className="ui header">
+          Request Help
+          {groupModeLabel}
+        </h4>
         <div className="ui form">
           <div className="field">
             <label>Location</label>

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -11,6 +11,7 @@ class QueueChannel < ApplicationCable::Channel
 
     new_request = @course_queue.request(
       requester: current_user,
+      group: current_user.course_group_for_course(@course_queue.course),
       location: data['location'],
       description: data['description']
     )
@@ -113,7 +114,12 @@ class QueueChannel < ApplicationCable::Channel
         raise "Current user not instructor" 
       end
     elsif requirement == :current_user_only
-      unless current_user == request.requester
+      group = current_user.course_group_for_course(@course_queue.course)
+      if current_user == request.requester
+        return
+      elsif @course_queue.group_mode && group && group.id == request.course_group_id
+        return
+      else
         raise "Current user not requester" 
       end
     elsif requirement == :open_queue 

--- a/app/controllers/admin/course_queues_controller.rb
+++ b/app/controllers/admin/course_queues_controller.rb
@@ -56,6 +56,6 @@ class Admin::CourseQueuesController < Admin::AdminController
   end
 
   def course_queue_params
-    params.require(:course_queue).permit(:name, :location, :description, :course_id)
+    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode)
   end
 end

--- a/app/controllers/course_queues_controller.rb
+++ b/app/controllers/course_queues_controller.rb
@@ -3,7 +3,13 @@ class CourseQueuesController < ApplicationController
 
   # GET /course_queues/1
   def show
-    @is_instructor =current_user.instructor_for_course_queue?(@course_queue).to_s 
+    @is_instructor = current_user.instructor_for_course_queue?(@course_queue).to_s
+
+    if course_group = current_user.course_group_for_course(@course_queue.course)
+      @course_group_id = course_group.id.to_s
+    else
+      @course_group_id = "null" # this is going to get serialized
+    end
   end
 
   # GET /course_queues/1/outstanding_requests.json

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,7 @@ class Course < ApplicationRecord
   has_many :course_instructors
   has_many :instructors, through: :course_instructors
   has_many :course_queue_entries, through: :course_queues
+  has_many :course_groups
 
   # Produce a deterministic but secret code used to self-enroll instructors
   def enrollment_code

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -68,6 +68,16 @@ class Course < ApplicationRecord
     course_queue_entries.where.not(resolved_at: nil).order('resolved_at DESC').limit(limit)
   end
 
+  def get_group_string
+    groups = []
+
+    course_groups.each do |group|
+      groups << group.students.pluck(:email).join(',')
+    end
+
+    groups.join("\n")
+  end
+
   def to_param
     slug
   end

--- a/app/models/course_group.rb
+++ b/app/models/course_group.rb
@@ -1,5 +1,5 @@
 class CourseGroup < ApplicationRecord
   belongs_to :course
-  has_many :course_group_students
+  has_many :course_group_students, dependent: :destroy
   has_many :students, through: :course_group_students, class_name: 'User'
 end

--- a/app/models/course_group.rb
+++ b/app/models/course_group.rb
@@ -1,0 +1,5 @@
+class CourseGroup < ApplicationRecord
+  belongs_to :course
+  has_many :course_group_students
+  has_many :students, through: :course_group_students, class_name: 'User'
+end

--- a/app/models/course_group_student.rb
+++ b/app/models/course_group_student.rb
@@ -10,7 +10,7 @@ class CourseGroupStudent < ApplicationRecord
                       .where('course_groups.course_id': course_group.course.id,
                              student: student)
                       .count > 0
-      errors.add(:student_id, "already belongs to a group in this course")
+      errors.add(:student_id, "#{student.email} already belongs to a group in this course.")
     end
   end
 end

--- a/app/models/course_group_student.rb
+++ b/app/models/course_group_student.rb
@@ -1,0 +1,5 @@
+class CourseGroupStudent < ApplicationRecord
+  belongs_to :course_group
+  delegate :course, to: :course_group
+  belongs_to :student, class_name: 'User'
+end

--- a/app/models/course_group_student.rb
+++ b/app/models/course_group_student.rb
@@ -2,4 +2,15 @@ class CourseGroupStudent < ApplicationRecord
   belongs_to :course_group
   delegate :course, to: :course_group
   belongs_to :student, class_name: 'User'
+
+  validate :student_not_already_in_group_for_course
+
+  def student_not_already_in_group_for_course
+    if CourseGroupStudent.joins(:course_group)
+                      .where('course_groups.course_id': course_group.course.id,
+                             student: student)
+                      .count > 0
+      errors.add(:student_id, "already belongs to a group in this course")
+    end
+  end
 end

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -4,14 +4,22 @@ class CourseQueue < ApplicationRecord
   has_many :course_queue_online_instructors
   has_many :online_instructors, through: :course_queue_online_instructors, class_name: 'User'
 
-  def request(requester:, description:, location:)
+  def request(requester:, description:, location:, group:)
+    # Check the user's request limit
     if outstanding_requests.where(requester: requester).count > 0
       raise "Limit one open request per user"
+    end
+
+    # Now the group's
+    count = outstanding_requests.where(course_group: group).count
+    if group_mode && group && count > 0
+      raise "Limit one open request per group"
     end
 
     CourseQueueEntry.create!(
       course_queue: self,
       requester: requester,
+      course_group: group,
       description: description,
       location: location,
     )

--- a/app/models/course_queue_entry.rb
+++ b/app/models/course_queue_entry.rb
@@ -1,6 +1,7 @@
 class CourseQueueEntry < ApplicationRecord
   belongs_to :course_queue
   has_one :course, through: :course_queue
+  belongs_to :course_group, required: false
   belongs_to :requester, class_name: 'User'
   belongs_to :resolver, class_name: 'User', required: false
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,10 +59,12 @@ class User < ApplicationRecord
     }))
   end
 
-  def course_group_id_for_course(course)
-    CourseGroupStudent.joins(:course_group)
-                      .where('course_groups.course_id': course.id, student: self)
-                      .pluck(:course_group_id)
-                      .first
+  def course_group_for_course(course)
+    id = CourseGroupStudent.joins(:course_group)
+                           .where('course_groups.course_id': course.id, student: self)
+                           .pluck(:course_group_id)
+                           .first
+
+    id.nil? ? nil : CourseGroup.find(id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,4 +58,11 @@ class User < ApplicationRecord
       except: User::PROTECTED_FIELDS
     }))
   end
+
+  def course_group_id_for_course(course)
+    CourseGroupStudent.joins(:course_group)
+                      .where('course_groups.course_id': course.id, student: self)
+                      .pluck(:course_group_id)
+                      .first
+  end
 end

--- a/app/views/admin/course_queues/_form.html.erb
+++ b/app/views/admin/course_queues/_form.html.erb
@@ -8,6 +8,19 @@
         <%= f.label :location %>
         <%= f.text_field :location %>
     </div>
+
+    <div class="field">
+        <%= f.label :group_mode %>
+        <div class="ui small message">
+            <p>Import a list of groups for this course <a href="<%=
+            groups_admin_course_url(@course_queue.course) %>">here</a>.</p>
+        </div>
+        <div class="ui toggle checkbox">
+            <%= f.check_box :group_mode %>
+            <label>Enable course groups for this queue</label>
+        </div>
+    </div>
+
     <%= f.hidden_field :course_id %>
     <%= f.submit 'Submit', class: 'ui button' %>
 <% end %>

--- a/app/views/admin/courses/_groups.html.erb
+++ b/app/views/admin/courses/_groups.html.erb
@@ -1,0 +1,14 @@
+<% if @groups.empty? %>
+    <div class="ui message">
+        <strong>This course does not have any groups created.</strong>
+        Import a list of groups above, and enable group mode on queues to allow
+        students to share queue requests with their groupmmates and limit to
+        one request per group.
+    </div>
+<% else %>
+<pre style="width: 100%; font-family: monospace;" disabled>
+<% @groups.each do |group| %>
+<%= group.students.pluck(:email).join(',') %>
+<% end %>
+</pre>
+<% end %>

--- a/app/views/admin/courses/_queues.html.erb
+++ b/app/views/admin/courses/_queues.html.erb
@@ -1,7 +1,8 @@
 <table class="ui table">
     <thead>
         <tr><th style="width: 50%">Course Queue Name</th>
-            <th style="width: 50%">Location</th>
+            <th style="width: 40%">Location</th>
+            <th style="width: 10%">Group Mode</th>
             <th>
                 <a href="<%= new_admin_course_queue_path(@course) %>" class="ui primary labeled icon fluid button">
                     <i class="plus icon"></i>
@@ -14,6 +15,10 @@
             <tr>
                 <td><%= queue.name %></td>
                 <td><%= queue.location %></td>
+                <td><div class="ui disabled toggle checkbox">
+                        <input type="checkbox" disabled="disabled" <%= 'checked' if queue.group_mode %>>
+                        <label></label>
+                    </div></td>
                 <td>
                     <div class="ui fluid basic buttons">
                         <%= link_to 'Edit', edit_admin_course_queue_path(queue), class: 'ui button' %>

--- a/app/views/admin/courses/groups.html.erb
+++ b/app/views/admin/courses/groups.html.erb
@@ -1,0 +1,35 @@
+<%= render 'shared/breadcrumbs', trail: [
+    { title: @course.name, href: url_for(@course)},
+    'Groups'
+] %>
+
+<div class="sixteen wide column">
+    <h1 class="ui header">
+        <%= @course.name %> Course Groups
+    </h1>
+</div>
+
+<div class="eight wide column">
+    <% if @err.present? %>
+        <div class="ui error message">
+            <%= @err %>
+        </div>
+    <% end %>
+
+    <p>Upload a comma-separated list of emails. One group per line. e.g.</p>
+    <pre>
+bob@umich.edu,mary@umich.edu,sue@umich.edu
+josh@umich.edu,matt@umich.edu,anna@umich.edu</pre>
+    <p>Would create two groups: [Bob, Mary, Sue] and [Josh, Matt, Anna].</p>
+    <%= form_tag(nil, {class: 'ui form'}) do %>
+        <div class="field">
+            <textarea name="groups"
+             style="font-family: monospace;"
+             placeholder="user1@umich.edu,user2@umich.edu,user3@umich.edu"
+             ><%= h(@course_group_string) %></textarea>
+        </div>
+        <div class="field">
+            <button type="submit" class="ui button">Upload</div>
+        </div>
+    <% end %>
+</div>

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -16,6 +16,13 @@
     <h2>Course Queues</h2>
     <%= render 'queues', queues: @queues %>
 
+    <h2>Course Groups
+        <a class="ui labeled icon right floated primary button" href="<%= groups_admin_course_url(@course) %>">
+            <i class="plus icon"></i>
+        Import</a>
+    </h2>
+    <%= render 'groups', groups: @groups %>
+
     <h2>Course Instructors</h2>
     <%= render 'self_enroll', code: @course.enrollment_code %>
     <%= render 'instructors', instructors: @instructors %>

--- a/app/views/course_queues/show.html.erb
+++ b/app/views/course_queues/show.html.erb
@@ -12,6 +12,8 @@
           queueName={"<%= j @course_queue.name.html_safe %>"}
           queueLoc={"<%= j @course_queue.location.html_safe %>"}
           currentUserId={<%= current_user.id %>}
+          courseGroupId={<%= @course_group_id %>}
+          groupMode={<%= @course_queue.group_mode.to_s %>}
           instructor={<%= @is_instructor %>}
           id={<%= @course_queue.id %>}
       />,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     resources :courses do
       member do
         get :statistics
+        get :groups
+        post :groups
         resources :course_queues, only: [:new]
         resources :course_instructors, only: [:new] do
           get :promote, on: :collection

--- a/db/migrate/20170213153606_create_groups.rb
+++ b/db/migrate/20170213153606_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :course_groups do |t|
+      t.belongs_to :course, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170213153910_add_mode_to_course_queue.rb
+++ b/db/migrate/20170213153910_add_mode_to_course_queue.rb
@@ -1,0 +1,5 @@
+class AddModeToCourseQueue < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_queues, :group_mode, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20170213154725_create_course_group_students.rb
+++ b/db/migrate/20170213154725_create_course_group_students.rb
@@ -1,0 +1,10 @@
+class CreateCourseGroupStudents < ActiveRecord::Migration[5.0]
+  def change
+    create_table :course_group_students do |t|
+      t.integer :course_group_id, null: false
+      t.integer :student_id, null: false
+    end
+
+    add_index :course_group_students, :student_id
+  end
+end

--- a/db/migrate/20170213155634_add_group_to_course_queue_entry.rb
+++ b/db/migrate/20170213155634_add_group_to_course_queue_entry.rb
@@ -1,0 +1,5 @@
+class AddGroupToCourseQueueEntry < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_queue_entries, :course_group_id, :integer
+  end
+end

--- a/db/migrate/20170215215714_key_on_student_and_course.rb
+++ b/db/migrate/20170215215714_key_on_student_and_course.rb
@@ -1,0 +1,5 @@
+class KeyOnStudentAndCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_index :course_group_students, [ :student_id, :course_group_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170215204213) do
+ActiveRecord::Schema.define(version: 20170215215714) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false
     t.integer "student_id",      null: false
+    t.index ["student_id", "course_group_id"], name: "index_course_group_students_on_student_id_and_course_group_id", unique: true, using: :btree
     t.index ["student_id"], name: "index_course_group_students_on_student_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170102061150) do
+ActiveRecord::Schema.define(version: 20170215204213) do
+
+  create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.integer "course_group_id", null: false
+    t.integer "student_id",      null: false
+    t.index ["student_id"], name: "index_course_group_students_on_student_id", using: :btree
+  end
+
+  create_table "course_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.integer  "course_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "index_course_groups_on_course_id", using: :btree
+  end
 
   create_table "course_instructors", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "course_id",     null: false
@@ -29,6 +42,8 @@ ActiveRecord::Schema.define(version: 20170102061150) do
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.string   "location"
+    t.boolean  "anonymous"
+    t.integer  "course_group_id"
     t.index ["course_queue_id"], name: "index_course_queue_entries_on_course_queue_id", using: :btree
   end
 
@@ -41,13 +56,14 @@ ActiveRecord::Schema.define(version: 20170102061150) do
   end
 
   create_table "course_queues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name",                      null: false
+    t.string   "name",                                      null: false
     t.string   "location"
     t.text     "description", limit: 65535
     t.boolean  "is_open"
-    t.integer  "course_id",                 null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.integer  "course_id",                                 null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
+    t.boolean  "group_mode",                default: false, null: false
     t.index ["course_id", "name"], name: "index_course_queues_on_course_id_and_name", unique: true, using: :btree
   end
 

--- a/test/fixtures/course_groups.yml
+++ b/test/fixtures/course_groups.yml
@@ -1,0 +1,16 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+group1:
+  course: eecs482
+  students:
+      - matt
+      - steve
+
+group2:
+  course: eecs482
+  students:
+      - jim
+      - mary
+
+group3:
+  course: eecs398

--- a/test/fixtures/course_instructors.yml
+++ b/test/fixtures/course_instructors.yml
@@ -3,3 +3,7 @@
 matt_eecs398:
   course: eecs398
   instructor: matt
+
+matt_eecs482:
+  course: eecs482
+  instructor: matt

--- a/test/fixtures/course_queues.yml
+++ b/test/fixtures/course_queues.yml
@@ -6,6 +6,15 @@ eecs398_queue:
   description: ''
   is_open: true
   course: eecs398
+  group_mode: false
+
+eecs482_group_queue:
+  name: Project Help
+  location: 1670 BBB
+  description: ''
+  is_open: true
+  course: eecs482
+  group_mode: true
 
 closed_queue:
   name: I am not real

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -4,3 +4,8 @@ eecs398:
   name: EECS 398
   long_name: Computing for Computer Scientists
   slug: eecs398
+
+eecs482:
+  name: EECS 482
+  long_name: Operating Systems
+  slug: eecs482

--- a/test/models/course_group_test.rb
+++ b/test/models/course_group_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class CourseGroupTest < ActiveSupport::TestCase
+  test "the same student can be in the same group once" do
+    assert_raise ActiveRecord::RecordInvalid do
+      course_groups(:group1).students << users(:matt)
+    end
+  end
+
+  test "the same student cannot be in multiple groups per course" do
+    assert_raise ActiveRecord::RecordInvalid do
+      course_groups(:group2).students << users(:matt)
+    end
+  end
+
+  test "the same student can be in groups in multiple courses" do
+    course_groups(:group3).students << users(:matt)
+  end
+end

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 
 class CourseQueueTest < ActiveSupport::TestCase
   setup do
-    @queue     = course_queues(:eecs398_queue)
-    @requester = users(:matt)
+    @queue       = course_queues(:eecs398_queue)
+    @group_queue = course_queues(:eecs482_group_queue)
+    @requester   = users(:matt)
   end
 
   test "request creates a new CourseQueueEntry for this queue" do
@@ -49,15 +50,52 @@ class CourseQueueTest < ActiveSupport::TestCase
   end
 
   test "request validates duplicates" do
-    assert_raise do
+    assert_raise RuntimeError do
       2.times {
         @queue.request(
           requester: users(:steve),
           description: '',
-          location: ''
+          location: '',
+          group: nil
         )
       }
     end
+  end
+
+  test "request validates duplicates in group mode" do
+    @group_queue.request(
+      requester: users(:steve),
+      description: '',
+      location: '',
+      group: course_groups(:group1)
+    )
+
+    assert_raise RuntimeError do
+      @group_queue.request(
+        requester: users(:matt),
+        description: '',
+        location: '',
+        group: course_groups(:group1)
+      )
+    end
+  end
+
+  test "request ignores group if group mode is off" do
+    @group_queue.update!(group_mode: false)
+
+    @group_queue.request(
+      requester: users(:steve),
+      description: '',
+      location: '',
+      group: course_groups(:group1)
+    )
+
+    @group_queue.request(
+      requester: users(:matt),
+      description: '',
+      location: '',
+      group: course_groups(:group1)
+    )
   end
 
   test "open queues returns only open queues" do

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -10,7 +10,8 @@ class CourseQueueTest < ActiveSupport::TestCase
     entry = @queue.request(
       requester: @requester,
       description: '',
-      location: ''
+      location: '',
+      group: nil
     )
 
     assert entry.course_queue == @queue
@@ -33,13 +34,15 @@ class CourseQueueTest < ActiveSupport::TestCase
     first_entry = @queue.request(
       requester: users(:sue),
       description: '',
-      location: ''
+      location: '',
+      group: nil
     )
 
     last_entry = @queue.request(
       requester: users(:jim),
       description: '',
-      location: ''
+      location: '',
+      group: nil
     )
 
     assert @queue.outstanding_requests[-1] == last_entry

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -11,4 +11,13 @@ class CourseTest < ActiveSupport::TestCase
     assert     open_queues.include? course_queues(:eecs398_queue)
     assert_not open_queues.include? course_queues(:closed_queue)
   end
+
+  test "group string serializes correctly" do
+    group_string = <<-EOF
+steve@umich.edu,mterwil@umich.edu
+marysmith@umich.edu,jimbob@umich.edu
+EOF
+
+    assert courses(:eecs482).get_group_string.strip == group_string.strip
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,13 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "course_group_for_course returns nil if no course" do
+    group = users(:matt).course_group_for_course(courses(:eecs398))
+    assert group == nil
+  end
+
+  test "course_group_for_course returns the correct CourseGroup" do
+    group = users(:matt).course_group_for_course(courses(:eecs482))
+    assert group == course_groups(:group1)
+  end
 end


### PR DESCRIPTION
Support enqueueing by instructor-defined student groups.

- Instructors upload a csv containing emails of students to group
- Instructors enable "group mode" on a per-queue basis
- When on, students will be limited to 1 request per group
- Anyone in the same group will be able to update the request
- The student who enqueued will still show as the primary requester

Closes #66
Closes #73

#### To-Do
- [x] Add course queue toggle
- [x] Fix test cases
- [x] Add new test cases for group mode
- [x] Update frontend added in 8705c72dfef595aaba3aa9b7865924ac469c14e8 to also highlight the current group's request.